### PR TITLE
fix: Epic Fight tooltip check local player

### DIFF
--- a/src/main/java/io/github/settingdust/dawncraftfixes/mixin/epicfight/MixingRenderEngineEvents.java
+++ b/src/main/java/io/github/settingdust/dawncraftfixes/mixin/epicfight/MixingRenderEngineEvents.java
@@ -1,0 +1,20 @@
+package io.github.settingdust.dawncraftfixes.mixin.epicfight;
+
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import yesman.epicfight.client.events.engine.RenderEngine;
+
+import java.util.Objects;
+
+@Mixin(RenderEngine.Events.class)
+public class MixingRenderEngineEvents
+{
+    @Inject(remap = false, method = "itemTooltip",at = @At("HEAD"), cancellable = true)
+    private static void dcfixes$wrongNameOfSetSwag(ItemTooltipEvent tooltipEvent, CallbackInfo callbackInfo) {
+        if(!Objects.requireNonNull(tooltipEvent.getPlayer()).getLevel().isClientSide)
+            callbackInfo.cancel();
+    }
+}

--- a/src/main/java/io/github/settingdust/dawncraftfixes/mixin/epicfight/MixingRenderEngineEvents.java
+++ b/src/main/java/io/github/settingdust/dawncraftfixes/mixin/epicfight/MixingRenderEngineEvents.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 public class MixingRenderEngineEvents
 {
     @Inject(remap = false, method = "itemTooltip",at = @At("HEAD"), cancellable = true)
-    private static void dcfixes$wrongNameOfSetSwag(ItemTooltipEvent tooltipEvent, CallbackInfo callbackInfo) {
+    private static void dcfixes$missingClientCheck(ItemTooltipEvent tooltipEvent, CallbackInfo callbackInfo) {
         if(!Objects.requireNonNull(tooltipEvent.getPlayer()).getLevel().isClientSide)
             callbackInfo.cancel();
     }

--- a/src/main/resources/dawncraft-fixes.mixins.json
+++ b/src/main/resources/dawncraft-fixes.mixins.json
@@ -28,6 +28,7 @@
     "defaultRequire": 1
   },
   "client": [
-    "callablehorses.MixinGuiStatViewer"
+    "callablehorses.MixinGuiStatViewer",
+    "epicfight.MixingRenderEngineEvents"
   ]
 }


### PR DESCRIPTION
A first approach that fixes the missing client check inside the TooltipEvent